### PR TITLE
feat: Phase-1 Maia <-> ALMA memory gateway adapter

### DIFF
--- a/integrations/maia/README.md
+++ b/integrations/maia/README.md
@@ -1,0 +1,139 @@
+# Maia <-> ALMA Memory Adapter (Phase 1)
+
+Backs the **Maia** gateway's memory with [ALMA](../../README.md). The
+iMetaClaw / OpenGlasses app talks to the Maia gateway over WebSocket JSON-RPC;
+this adapter implements the two memory methods on top of ALMA.
+
+> **Scope: Phase 1 only — facts-first read + write.** Outcome/strategy/confidence
+> enrichment (Phase 3) and RN parity / cross-device / HIPAA pruning (Phase 4) are
+> deliberately **not** built here. See [Deferred](#deferred).
+
+## Device contract (the shapes you must honor)
+
+Verified in `OpenGlasses/Sources/Services/OpenClawBridge.swift:1172-1206`:
+
+| Method         | Params                          | Success response                                                  |
+| -------------- | ------------------------------- | ----------------------------------------------------------------- |
+| `memory.query` | `{query: string, limit: int}`   | `{"ok": true, "payload": {"results": [{"content": string}, ...]}}` |
+| `memory.store` | `{content: string, metadata: object}` | `{"ok": true}`                                              |
+
+The adapter never raises into the RPC layer. On any failure it returns
+`{"ok": false, "error": "..."}`, and **empty memory is a success with empty
+results**, not an error.
+
+## Files
+
+| File                          | Purpose                                                        |
+| ----------------------------- | -------------------------------------------------------------- |
+| `alma_gateway_adapter.py`     | The two handlers + `build_alma()` factory. Framework-agnostic. |
+| `spike_roundtrip.py`          | Runnable Phase-0 spike: store 2 facts, query them back.        |
+| `test_alma_gateway_adapter.py`| Unit tests against a fake in-memory ALMA (no model/network).   |
+
+## Interface
+
+```python
+from integrations.maia.alma_gateway_adapter import (
+    build_alma, handle_memory_query, handle_memory_store,
+)
+
+alma = build_alma()  # ALMA.quickstart() local backend; or build_alma("/path/config.yaml")
+
+handle_memory_query({"query": "deploy steps", "limit": 10}, alma=alma)
+# -> {"ok": True, "payload": {"results": [{"content": "..."}, ...]}}
+
+handle_memory_store({"content": "Caddy fronts :3600", "metadata": {"persona": "maia"}}, alma=alma)
+# -> {"ok": True}
+```
+
+- `agent` defaults to `"maia"`. `metadata.persona` (when present) overrides the
+  ALMA agent/scope per call. A `user_id` / `userId` / `user` in metadata is
+  threaded into `retrieve()` when present.
+- The adapter has **no top-level `alma` import** — only `build_alma()` imports it
+  lazily — so the module imports cleanly without `alma-memory` installed, and the
+  unit tests run against a fake.
+
+### Import path
+
+The module is `integrations.maia.alma_gateway_adapter`. Import it relative to the
+repo root (the directory containing `integrations/`). On the VPS, either run the
+gateway from the repo root or add the repo root to `PYTHONPATH`:
+
+```bash
+export PYTHONPATH=/opt/maia/alma-integration:$PYTHONPATH
+```
+
+## Phase-0 spike (do this first on the VPS)
+
+```bash
+python3 -m venv /opt/maia/venv && source /opt/maia/venv/bin/activate
+pip install 'alma-memory[local]'        # SQLite + sentence-transformers, zero keys
+
+# REPL round trip:
+python - <<'PY'
+from alma import ALMA
+alma = ALMA.quickstart(project_id="maia")
+alma.add_domain_knowledge(agent="maia", domain="maia_memory", fact="hello from maia")
+print([dk.fact for dk in alma.retrieve(task="hello", agent="maia", top_k=5).domain_knowledge])
+PY
+
+# Or run the bundled spike (from the repo root):
+python integrations/maia/spike_roundtrip.py
+```
+
+The first `quickstart()` downloads the sentence-transformers model (~80 MB);
+subsequent runs are offline. SQLite lands under `./.alma/alma.db`.
+
+## Wiring into the Maia gateway dispatcher
+
+The Maia gateway lives on the user's VPS (not in any repo), listening on
+`127.0.0.1:3600` behind Caddy on `:443`. Build one ALMA instance at startup and
+route the two methods to the handlers. Sketch:
+
+```python
+from integrations.maia.alma_gateway_adapter import (
+    build_alma, handle_memory_query, handle_memory_store,
+)
+
+ALMA_INSTANCE = build_alma()  # once, at process start
+
+def dispatch(method: str, params: dict) -> dict:
+    if method == "memory.query":
+        return handle_memory_query(params, alma=ALMA_INSTANCE)
+    if method == "memory.store":
+        return handle_memory_store(params, alma=ALMA_INSTANCE)
+    # ... existing methods ...
+```
+
+Notes:
+- Build ALMA **once** and reuse it; `quickstart()` eagerly loads the embedder.
+- ALMA is synchronous. If the dispatcher is `async`, run the handlers in a
+  thread executor (`loop.run_in_executor(...)`) so embedding work does not block
+  the WebSocket event loop.
+- Keep `.alma/` on persistent disk so memory survives restarts; back it up.
+
+## Tests
+
+From the repo root (use the project venv if present, e.g. `/tmp/alma-venv`):
+
+```bash
+python -m pytest integrations/maia/ -q
+```
+
+Tests use a **fake in-memory ALMA**, so they pass without `sentence-transformers`
+or network access. They cover query shape, empty-memory path, persona routing,
+store ok/persist, bad-params -> `{ok: False}`, backend-failure isolation, and a
+store->query round trip.
+
+## Deferred
+
+These are explicit TODOs, intentionally out of Phase 1:
+
+- **Phase 3 — schema/contract enrichment.** Thread task outcome, `strategy_used`,
+  and confidence through the RPC and call `alma.learn(...)` (and surface
+  heuristic confidence in `memory.query` results). Today `memory.store` only
+  writes facts via `add_domain_knowledge`; `learn()` is not invoked.
+- **Phase 4 — RN parity / cross-device.** Match the React Native client's memory
+  shape and reconcile per-device vs shared memory scopes.
+- **Phase 4 — HIPAA server-side pruning.** Server-side retention/redaction of PHI
+  before persistence; ALMA scope/TTL policy enforcement on stored content.
+```

--- a/integrations/maia/alma_gateway_adapter.py
+++ b/integrations/maia/alma_gateway_adapter.py
@@ -25,14 +25,23 @@ is Phase 3 (see TODOs). RN parity / cross-device / HIPAA pruning is Phase 4.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional
 
 __all__ = ["handle_memory_query", "handle_memory_store", "build_alma"]
+
+logger = logging.getLogger(__name__)
 
 # Default ALMA "domain" bucket for facts written through the gateway.
 _DEFAULT_DOMAIN = "maia_memory"
 # Default top_k when the device omits `limit`.
 _DEFAULT_LIMIT = 10
+# Hard cap on top_k so a hostile/buggy caller cannot force an unbounded scan.
+_MAX_LIMIT = 100
+# Max UTF-8 byte length for caller-supplied text (`content` / `query`). Guards
+# against memory/DoS from oversized payloads. Reject over-limit rather than
+# silently truncating (clearer contract + testable).
+MAX_CONTENT_BYTES = 32 * 1024
 
 
 def _slice_to_contents(memory_slice: Any) -> List[str]:
@@ -94,9 +103,13 @@ def handle_memory_query(
         if not isinstance(query, str) or not query.strip():
             return {"ok": False, "error": "missing or invalid 'query'"}
 
+        if len(query.encode("utf-8")) > MAX_CONTENT_BYTES:
+            return {"ok": False, "error": "input too large"}
+
         limit = params.get("limit", _DEFAULT_LIMIT)
         if not isinstance(limit, int) or limit <= 0:
             limit = _DEFAULT_LIMIT
+        limit = min(limit, _MAX_LIMIT)
 
         resolved_agent = _resolve_agent(params.get("metadata"), agent)
         user_id = _resolve_user_id(params.get("metadata"))
@@ -110,8 +123,11 @@ def handle_memory_query(
 
         results = [{"content": c} for c in _slice_to_contents(memory_slice)]
         return {"ok": True, "payload": {"results": results}}
-    except Exception as exc:  # never raise into the RPC layer
-        return {"ok": False, "error": f"memory.query failed: {exc}"}
+    except Exception:  # never raise into the RPC layer
+        # Log real detail server-side; return a generic message to the caller so
+        # DB path / schema / SQL do not leak across the RPC boundary.
+        logger.exception("memory.query failed")
+        return {"ok": False, "error": "internal error"}
 
 
 def handle_memory_store(
@@ -142,6 +158,9 @@ def handle_memory_store(
         if not isinstance(content, str) or not content.strip():
             return {"ok": False, "error": "missing or invalid 'content'"}
 
+        if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+            return {"ok": False, "error": "input too large"}
+
         metadata = params.get("metadata")
         if metadata is not None and not isinstance(metadata, dict):
             return {"ok": False, "error": "'metadata' must be an object"}
@@ -155,8 +174,11 @@ def handle_memory_store(
             source="user_stated",
         )
         return {"ok": True}
-    except Exception as exc:  # never raise into the RPC layer
-        return {"ok": False, "error": f"memory.store failed: {exc}"}
+    except Exception:  # never raise into the RPC layer
+        # Log real detail server-side; return a generic message to the caller so
+        # DB path / schema / SQL do not leak across the RPC boundary.
+        logger.exception("memory.store failed")
+        return {"ok": False, "error": "internal error"}
 
 
 def _resolve_agent(metadata: Optional[Dict[str, Any]], default: str) -> str:

--- a/integrations/maia/alma_gateway_adapter.py
+++ b/integrations/maia/alma_gateway_adapter.py
@@ -1,0 +1,198 @@
+"""ALMA <-> Maia gateway adapter (Phase 1: facts-first read + write).
+
+This module is self-contained and framework-agnostic. It exposes two JSON-RPC
+handlers that the Maia gateway dispatcher (running on the user's VPS) wires into
+its `memory.query` / `memory.store` methods, backing Maia's memory with ALMA.
+
+Device contract (verified in the iMetaClaw/OpenGlasses app,
+OpenClawBridge.swift:1172-1206):
+
+    memory.query  params {query: str, limit: int}
+                  -> {"ok": True, "payload": {"results": [{"content": str}, ...]}}
+    memory.store  params {content: str, metadata: object}
+                  -> {"ok": True}
+
+Design notes:
+- `alma` is passed in as a duck-typed dependency, so this module imports WITHOUT
+  the `alma-memory` package installed. Only `build_alma()` imports `alma` lazily.
+- Handlers NEVER raise into the RPC layer. Any failure is mapped to
+  `{"ok": False, "error": "..."}` so the WebSocket dispatcher stays alive.
+- Empty memory is a success with empty results, NOT an error.
+
+Scope: Phase 1 only. Outcome/confidence/strategy enrichment via `alma.learn()`
+is Phase 3 (see TODOs). RN parity / cross-device / HIPAA pruning is Phase 4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+__all__ = ["handle_memory_query", "handle_memory_store", "build_alma"]
+
+# Default ALMA "domain" bucket for facts written through the gateway.
+_DEFAULT_DOMAIN = "maia_memory"
+# Default top_k when the device omits `limit`.
+_DEFAULT_LIMIT = 10
+
+
+def _slice_to_contents(memory_slice: Any) -> List[str]:
+    """Flatten an ALMA MemorySlice into a list of human-readable strings.
+
+    Phase 1 is facts-first, so domain-knowledge facts lead. We also surface the
+    other readable memory types so a query is not silently empty when only
+    heuristics / preferences exist for the agent.
+    """
+    contents: List[str] = []
+
+    # Facts first (Phase 1 primary path).
+    for dk in getattr(memory_slice, "domain_knowledge", None) or []:
+        fact = getattr(dk, "fact", None)
+        if fact:
+            contents.append(str(fact))
+
+    for h in getattr(memory_slice, "heuristics", None) or []:
+        condition = getattr(h, "condition", "")
+        strategy = getattr(h, "strategy", "")
+        if condition or strategy:
+            contents.append(f"When {condition}: {strategy}".strip())
+
+    for pref in getattr(memory_slice, "preferences", None) or []:
+        text = getattr(pref, "preference", None)
+        if text:
+            contents.append(str(text))
+
+    for ap in getattr(memory_slice, "anti_patterns", None) or []:
+        pattern = getattr(ap, "pattern", "")
+        better = getattr(ap, "better_alternative", "")
+        if pattern:
+            contents.append(f"Avoid: {pattern}. Instead: {better}".strip())
+
+    return contents
+
+
+def handle_memory_query(
+    params: Dict[str, Any],
+    *,
+    alma: Any,
+    agent: str = "maia",
+) -> Dict[str, Any]:
+    """Handle a `memory.query` RPC call.
+
+    Args:
+        params: RPC params. Expects `query: str` and optional `limit: int`.
+        alma: An ALMA instance (or compatible) exposing `.retrieve(...)`.
+        agent: ALMA agent namespace to read from. May be overridden per call by
+            `params["metadata"]["persona"]` when present.
+
+    Returns:
+        `{"ok": True, "payload": {"results": [{"content": str}, ...]}}` on
+        success (empty results when memory is empty), or
+        `{"ok": False, "error": str}` on any failure.
+    """
+    try:
+        query = params.get("query")
+        if not isinstance(query, str) or not query.strip():
+            return {"ok": False, "error": "missing or invalid 'query'"}
+
+        limit = params.get("limit", _DEFAULT_LIMIT)
+        if not isinstance(limit, int) or limit <= 0:
+            limit = _DEFAULT_LIMIT
+
+        resolved_agent = _resolve_agent(params.get("metadata"), agent)
+        user_id = _resolve_user_id(params.get("metadata"))
+
+        memory_slice = alma.retrieve(
+            task=query,
+            agent=resolved_agent,
+            top_k=limit,
+            **({"user_id": user_id} if user_id else {}),
+        )
+
+        results = [{"content": c} for c in _slice_to_contents(memory_slice)]
+        return {"ok": True, "payload": {"results": results}}
+    except Exception as exc:  # never raise into the RPC layer
+        return {"ok": False, "error": f"memory.query failed: {exc}"}
+
+
+def handle_memory_store(
+    params: Dict[str, Any],
+    *,
+    alma: Any,
+    agent: str = "maia",
+) -> Dict[str, Any]:
+    """Handle a `memory.store` RPC call.
+
+    Stores the content as ALMA domain knowledge (a fact). The `persona` in
+    metadata, when present, selects the ALMA agent/scope; a `user_id` in
+    metadata is derived and threaded through where ALMA supports it.
+
+    Note: Recording task outcome / strategy / confidence via `alma.learn()`
+    is Phase 3 and intentionally NOT done here. Phase 1 stores facts only.
+
+    Args:
+        params: RPC params. Expects `content: str` and optional `metadata: dict`.
+        alma: An ALMA instance (or compatible) exposing `.add_domain_knowledge`.
+        agent: Default ALMA agent namespace; overridden by metadata persona.
+
+    Returns:
+        `{"ok": True}` on success, or `{"ok": False, "error": str}` on failure.
+    """
+    try:
+        content = params.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return {"ok": False, "error": "missing or invalid 'content'"}
+
+        metadata = params.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            return {"ok": False, "error": "'metadata' must be an object"}
+
+        resolved_agent = _resolve_agent(metadata, agent)
+
+        alma.add_domain_knowledge(
+            agent=resolved_agent,
+            domain=_DEFAULT_DOMAIN,
+            fact=content,
+            source="user_stated",
+        )
+        return {"ok": True}
+    except Exception as exc:  # never raise into the RPC layer
+        return {"ok": False, "error": f"memory.store failed: {exc}"}
+
+
+def _resolve_agent(metadata: Optional[Dict[str, Any]], default: str) -> str:
+    """Map `metadata.persona` to an ALMA agent/scope name, falling back to default."""
+    if isinstance(metadata, dict):
+        persona = metadata.get("persona")
+        if isinstance(persona, str) and persona.strip():
+            return persona.strip()
+    return default
+
+
+def _resolve_user_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Derive a user_id from metadata when the device supplies one."""
+    if isinstance(metadata, dict):
+        for key in ("user_id", "userId", "user"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def build_alma(config_path: Optional[str] = None) -> Any:
+    """Factory: build a ready-to-use ALMA instance.
+
+    Imports `alma` lazily so this module is importable without the package.
+
+    Args:
+        config_path: Path to an ALMA config.yaml. If None, uses the zero-key
+            local backend via `ALMA.quickstart()` (SQLite + sentence-transformers;
+            requires `pip install 'alma-memory[local]'`).
+
+    Returns:
+        An ALMA instance.
+    """
+    from alma import ALMA  # lazy: keeps the adapter importable without alma
+
+    if config_path:
+        return ALMA.from_config(config_path)
+    return ALMA.quickstart(project_id="maia")

--- a/integrations/maia/spike_roundtrip.py
+++ b/integrations/maia/spike_roundtrip.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Phase-0 spike: prove a store -> query round trip through the adapter.
+
+Builds a real local ALMA (SQLite + sentence-transformers), stores two facts via
+`handle_memory_store`, then queries via `handle_memory_query` and prints results.
+
+Prerequisites:
+    pip install 'alma-memory[local]'
+
+Run (from the repo root):
+    python integrations/maia/spike_roundtrip.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from integrations.maia.alma_gateway_adapter import (
+    build_alma,
+    handle_memory_query,
+    handle_memory_store,
+)
+
+
+def main() -> int:
+    print("Building local ALMA (quickstart: SQLite + local embeddings)...")
+    try:
+        alma = build_alma()  # no config_path -> ALMA.quickstart()
+    except ImportError as exc:
+        print(f"\n[spike] ALMA local backend unavailable: {exc}")
+        print("[spike] Install it with: pip install 'alma-memory[local]'")
+        return 1
+
+    facts = [
+        "The Maia gateway runs on 127.0.0.1:3600 behind Caddy on :443.",
+        "ALMA backs Maia memory via memory.query and memory.store RPC methods.",
+    ]
+
+    print("\nStoring 2 facts via handle_memory_store...")
+    for fact in facts:
+        result = handle_memory_store(
+            {"content": fact, "metadata": {"persona": "maia"}}, alma=alma
+        )
+        print(f"  store -> {result}")
+        if not result.get("ok"):
+            print("[spike] store failed; aborting.")
+            return 1
+
+    print("\nQuerying via handle_memory_query (query='Maia gateway', limit=5)...")
+    query_result = handle_memory_query(
+        {"query": "Maia gateway", "limit": 5}, alma=alma
+    )
+    print(f"  ok={query_result.get('ok')}")
+    results = query_result.get("payload", {}).get("results", [])
+    print(f"  {len(results)} result(s):")
+    for item in results:
+        print(f"    - {item['content']}")
+
+    print("\n[spike] Round trip complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/maia/test_alma_gateway_adapter.py
+++ b/integrations/maia/test_alma_gateway_adapter.py
@@ -1,0 +1,169 @@
+"""Unit tests for the Maia <-> ALMA gateway adapter.
+
+These tests use a FAKE in-memory ALMA so they run WITHOUT the embeddings model
+or any network (`sentence-transformers` need not be installed). They validate
+the RPC contract surface, not ALMA's internals.
+
+Run:
+    python -m pytest integrations/maia/ -q
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from integrations.maia.alma_gateway_adapter import (
+    handle_memory_query,
+    handle_memory_store,
+)
+
+# --- Fake ALMA -------------------------------------------------------------
+
+
+@dataclass
+class _FakeFact:
+    fact: str
+
+
+@dataclass
+class _FakeSlice:
+    """Mimics alma.types.MemorySlice (only the fields the adapter reads)."""
+
+    domain_knowledge: List[_FakeFact] = field(default_factory=list)
+    heuristics: List[Any] = field(default_factory=list)
+    preferences: List[Any] = field(default_factory=list)
+    anti_patterns: List[Any] = field(default_factory=list)
+
+
+class FakeALMA:
+    """In-memory stand-in for alma.core.ALMA, matching the real signatures."""
+
+    def __init__(self) -> None:
+        self.facts: List[Dict[str, Any]] = []
+
+    def retrieve(
+        self,
+        task: str,
+        agent: str,
+        top_k: int = 5,
+        user_id: Optional[str] = None,
+    ) -> _FakeSlice:
+        matches = [
+            _FakeFact(fact=f["fact"])
+            for f in self.facts
+            if f["agent"] == agent
+        ][:top_k]
+        return _FakeSlice(domain_knowledge=matches)
+
+    def add_domain_knowledge(
+        self,
+        agent: str,
+        domain: str,
+        fact: str,
+        source: str = "user_stated",
+    ) -> None:
+        self.facts.append(
+            {"agent": agent, "domain": domain, "fact": fact, "source": source}
+        )
+
+
+class ExplodingALMA:
+    """Raises on every call — proves handlers never leak exceptions."""
+
+    def retrieve(self, *a: Any, **k: Any) -> Any:
+        raise RuntimeError("boom")
+
+    def add_domain_knowledge(self, *a: Any, **k: Any) -> Any:
+        raise RuntimeError("boom")
+
+
+# --- query -----------------------------------------------------------------
+
+
+def test_query_returns_contract_shape():
+    alma = FakeALMA()
+    alma.add_domain_knowledge(agent="maia", domain="d", fact="sky is blue")
+    out = handle_memory_query({"query": "sky", "limit": 5}, alma=alma)
+    assert out["ok"] is True
+    assert out["payload"]["results"] == [{"content": "sky is blue"}]
+
+
+def test_query_empty_memory_is_success_not_error():
+    out = handle_memory_query({"query": "anything"}, alma=FakeALMA())
+    assert out == {"ok": True, "payload": {"results": []}}
+
+
+def test_query_respects_limit():
+    alma = FakeALMA()
+    for i in range(5):
+        alma.add_domain_knowledge(agent="maia", domain="d", fact=f"fact {i}")
+    out = handle_memory_query({"query": "x", "limit": 2}, alma=alma)
+    assert len(out["payload"]["results"]) == 2
+
+
+def test_query_persona_routes_to_agent_scope():
+    alma = FakeALMA()
+    alma.add_domain_knowledge(agent="alice", domain="d", fact="alice fact")
+    alma.add_domain_knowledge(agent="maia", domain="d", fact="maia fact")
+    out = handle_memory_query(
+        {"query": "x", "metadata": {"persona": "alice"}}, alma=alma
+    )
+    assert out["payload"]["results"] == [{"content": "alice fact"}]
+
+
+def test_query_bad_params_returns_not_ok():
+    assert handle_memory_query({}, alma=FakeALMA())["ok"] is False
+    assert handle_memory_query({"query": ""}, alma=FakeALMA())["ok"] is False
+    assert handle_memory_query({"query": 123}, alma=FakeALMA())["ok"] is False
+
+
+def test_query_never_raises_on_backend_failure():
+    out = handle_memory_query({"query": "x"}, alma=ExplodingALMA())
+    assert out["ok"] is False
+    assert "error" in out
+
+
+# --- store -----------------------------------------------------------------
+
+
+def test_store_ok_and_persists():
+    alma = FakeALMA()
+    out = handle_memory_store({"content": "remember this", "metadata": {}}, alma=alma)
+    assert out == {"ok": True}
+    assert alma.facts[0]["fact"] == "remember this"
+    assert alma.facts[0]["agent"] == "maia"
+
+
+def test_store_persona_selects_agent():
+    alma = FakeALMA()
+    handle_memory_store(
+        {"content": "x", "metadata": {"persona": "bob"}}, alma=alma
+    )
+    assert alma.facts[0]["agent"] == "bob"
+
+
+def test_store_bad_params_returns_not_ok():
+    alma = FakeALMA()
+    assert handle_memory_store({}, alma=alma)["ok"] is False
+    assert handle_memory_store({"content": ""}, alma=alma)["ok"] is False
+    assert handle_memory_store({"content": "ok", "metadata": "nope"}, alma=alma)[
+        "ok"
+    ] is False
+    assert alma.facts == []  # nothing persisted on bad params
+
+
+def test_store_never_raises_on_backend_failure():
+    out = handle_memory_store({"content": "x"}, alma=ExplodingALMA())
+    assert out["ok"] is False
+    assert "error" in out
+
+
+# --- round trip ------------------------------------------------------------
+
+
+def test_store_then_query_round_trip():
+    alma = FakeALMA()
+    handle_memory_store({"content": "the eiffel tower is in paris"}, alma=alma)
+    out = handle_memory_query({"query": "eiffel", "limit": 10}, alma=alma)
+    assert {"content": "the eiffel tower is in paris"} in out["payload"]["results"]

--- a/integrations/maia/test_alma_gateway_adapter.py
+++ b/integrations/maia/test_alma_gateway_adapter.py
@@ -69,13 +69,39 @@ class FakeALMA:
 
 
 class ExplodingALMA:
-    """Raises on every call — proves handlers never leak exceptions."""
+    """Raises on every call — proves handlers never leak exceptions.
+
+    The exception text (`_SECRET_DETAIL`) stands in for the kind of internal
+    detail (DB path / schema / SQL) that must NOT reach the RPC caller.
+    """
 
     def retrieve(self, *a: Any, **k: Any) -> Any:
-        raise RuntimeError("boom")
+        raise RuntimeError(_SECRET_DETAIL)
 
     def add_domain_knowledge(self, *a: Any, **k: Any) -> Any:
-        raise RuntimeError("boom")
+        raise RuntimeError(_SECRET_DETAIL)
+
+
+# Sentinel that mimics a leaky internal error (e.g. a DB path in an SQL error).
+_SECRET_DETAIL = "sqlite3 error at /var/alma/secret.db: no such table: facts"
+
+
+class RecordingALMA(FakeALMA):
+    """FakeALMA that records the `top_k` it was called with (for cap tests)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_top_k: Optional[int] = None
+
+    def retrieve(
+        self,
+        task: str,
+        agent: str,
+        top_k: int = 5,
+        user_id: Optional[str] = None,
+    ) -> _FakeSlice:
+        self.last_top_k = top_k
+        return super().retrieve(task, agent, top_k=top_k, user_id=user_id)
 
 
 # --- query -----------------------------------------------------------------
@@ -124,6 +150,36 @@ def test_query_never_raises_on_backend_failure():
     assert "error" in out
 
 
+def test_query_error_is_generic_and_does_not_leak_internals():
+    out = handle_memory_query({"query": "x"}, alma=ExplodingALMA())
+    assert out == {"ok": False, "error": "internal error"}
+    # The raw exception text / DB path / SQL must never reach the caller.
+    assert _SECRET_DETAIL not in out["error"]
+    assert "sqlite3" not in out["error"]
+    assert "secret.db" not in out["error"]
+
+
+def test_query_clamps_oversized_limit_to_max():
+    alma = RecordingALMA()
+    alma.add_domain_knowledge(agent="maia", domain="d", fact="a fact")
+    out = handle_memory_query({"query": "x", "limit": 1_000_000}, alma=alma)
+    assert out["ok"] is True
+    # ALMA must be called with a clamped top_k (<= 100), never the raw 1,000,000.
+    assert alma.last_top_k is not None
+    assert alma.last_top_k <= 100
+
+
+def test_query_rejects_oversized_query():
+    alma = RecordingALMA()
+    big_query = "x" * (32 * 1024 + 1)  # > MAX_CONTENT_BYTES (32KB)
+    out = handle_memory_query({"query": big_query}, alma=alma)
+    assert out["ok"] is False
+    assert "error" in out
+    # Non-leaking rejection message; ALMA must not have been called.
+    assert _SECRET_DETAIL not in out["error"]
+    assert alma.last_top_k is None
+
+
 # --- store -----------------------------------------------------------------
 
 
@@ -157,6 +213,25 @@ def test_store_never_raises_on_backend_failure():
     out = handle_memory_store({"content": "x"}, alma=ExplodingALMA())
     assert out["ok"] is False
     assert "error" in out
+
+
+def test_store_error_is_generic_and_does_not_leak_internals():
+    out = handle_memory_store({"content": "x"}, alma=ExplodingALMA())
+    assert out == {"ok": False, "error": "internal error"}
+    assert _SECRET_DETAIL not in out["error"]
+    assert "sqlite3" not in out["error"]
+    assert "secret.db" not in out["error"]
+
+
+def test_store_rejects_oversized_content():
+    alma = FakeALMA()
+    big_content = "x" * (32 * 1024 + 1)  # > MAX_CONTENT_BYTES (32KB)
+    out = handle_memory_store({"content": big_content}, alma=alma)
+    assert out["ok"] is False
+    assert "error" in out
+    # Non-leaking rejection message; nothing persisted (ALMA never called).
+    assert _SECRET_DETAIL not in out["error"]
+    assert alma.facts == []
 
 
 # --- round trip ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Deploy-ready Phase-1 adapter bridging the **Maia gateway** and **ALMA memory**. Maps the gateway's `memory.query` / `memory.store` RPC calls onto ALMA's `retrieve()` / `add_domain_knowledge()` APIs.

Adds `integrations/maia/` (adapter + runbook + spike + tests). 11 tests passing.

## What it does

- **`memory.query`** -> `ALMA.retrieve()`
- **`memory.store`** -> `ALMA.add_domain_knowledge()`
- **Phase 1 scope: facts-first.** Stores and retrieves factual domain knowledge. Outcome/strategy enrichment is explicitly out of scope for this phase.

## Deployment

- Deploys on the user's VPS at `/opt/maia`.
- Requires `pip install alma-memory[local]` on the VPS.
- See the included runbook for the deploy procedure.

## Deferred (documented as TODOs)

- **Phase 3** — outcomes / strategy enrichment.
- **Phase 4** — RN parity and HIPAA considerations.

## Validation

- 11 tests passing in `integrations/maia/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)